### PR TITLE
Add channels support to api

### DIFF
--- a/relayr/api.py
+++ b/relayr/api.py
@@ -1048,7 +1048,7 @@ class Api(object):
         :rtype: channelID with credentials to connect to it
         """
 
-         url = '{0}/channels'.format(self.host)
+        url = '{0}/channels'.format(self.host)
         data = {'deviceId': deviceID, 'transport': transport}
         _, res = self.perform_request('POST', url,
                                       data=data, headers = self.headers)

--- a/relayr/api.py
+++ b/relayr/api.py
@@ -1037,38 +1037,36 @@ class Api(object):
         _, data = self.perform_request('GET', url, headers=self.headers)
         return data
 
-    def post_channels(self, deviceID, transport):
+    def create_channel(self, deviceID, transport):
         """
-        Create a new channel.
-        
+        Create a new channel to send device data to an end user with
+        generated credentials for connecting to it.
         :param deviceID: the device UUID
         :type deviceID: string
         :param transport: transport for channel (mqtt, websockets, etc.)
         :type transport: string
         :rtype: channelID with credentials to connect to it
         """
-
         url = '{0}/channels'.format(self.host)
         data = {'deviceId': deviceID, 'transport': transport}
         _, res = self.perform_request('POST', url,
                                       data=data, headers = self.headers)
         return res
 
-    def delete_channels(self, channelID):
+    def delete_channel(self, channelID):
         """
         Delete an existing channel by its id.
         
         :param channelID: the UUID of the channel
         :type channelID: string
-        :rtype: no content
         """
         url = '{0}/channels/{1}'.format(self.host, channelID)
         _, res = self.perform_request('DELETE', url, headers = self.headers)
         return res
 
-    def delete_channels_batch(self, deviceID = None, transport = None):
+    def delete_channel_batch(self, deviceID = None, transport = None):
         """
-        Delete user's channels by criteria.
+        Delete channels by criteria.
         
         :param deviceID: the device UUID
         :type deviceID: string

--- a/relayr/api.py
+++ b/relayr/api.py
@@ -1037,6 +1037,54 @@ class Api(object):
         _, data = self.perform_request('GET', url, headers=self.headers)
         return data
 
+    def post_channels(self, deviceID, transport):
+        """
+        Create a new channel.
+        
+        :param deviceID: the device UUID
+        :type deviceID: string
+        :param transport: transport for channel (mqtt, websockets, etc.)
+        :type transport: string
+        :rtype: channelID with credentials to connect to it
+        """
+
+         url = '{0}/channels'.format(self.host)
+        data = {'deviceId': deviceID, 'transport': transport}
+        _, res = self.perform_request('POST', url,
+                                      data=data, headers = self.headers)
+        return res
+
+    def delete_channels(self, channelID):
+        """
+        Delete an existing channel by its id.
+        
+        :param channelID: the UUID of the channel
+        :type channelID: string
+        :rtype: no content
+        """
+        url = '{0}/channels/{1}'.format(self.host, channelID)
+        _, res = self.perform_request('DELETE', url, headers = self.headers)
+        return res
+
+    def delete_channels_batch(self, deviceID = None, transport = None):
+        """
+        Delete user's channels by criteria.
+        
+        :param deviceID: the device UUID
+        :type deviceID: string
+        :param transport: transport for channel (mqtt, websockets, etc.)
+        :type transport: string
+        :rtype: list of deleted channelIDs
+        """
+        url = '{0}/channels'.format(self.host)
+        data = {}
+        if deviceID is not None:
+            data['deviceId'] = deviceID
+        if transport is not None:
+            data['transport'] = transport
+        _, res = self.perform_request('DELETE', url,
+                                      data = data, headers = self.headers)
+            
     ## TODO: remove in version 0.3.0
     def post_devices_supscription(self, deviceID):
         """


### PR DESCRIPTION
@deeplook Can you please do me a favour and merge this pull request into python-sdk? New functionality to add / delete channels is arriving ;) There will be a few more endpoints to add later, but these are essential and we use them in integration tests. 
I guess you also may wish to add a new Channel class can be potentially added to Python SDK for convenience. 