### PR TITLE
Add transmitter connector.

### DIFF
--- a/relayr/api.py
+++ b/relayr/api.py
@@ -1355,7 +1355,7 @@ class Api(object):
         _, data = self.perform_request('GET', url, headers=self.headers)
         return data
 
-    def post_transmitter(self, transmitterID, ownerID=None, name=None, connector=None):
+    def post_transmitter(self, transmitterID, ownerID=None, name=None, integrationType=None):
         """
         Register a new transmitter on the relayr platform.
 
@@ -1374,8 +1374,8 @@ class Api(object):
             data.update(owner=ownerID)
         if name is not None:
             data.update(name=name)
-        if connector is not None:
-            data.update(connector=connector)
+        if integrationType is not None:
+            data.update(integrationType=integrationType)
 
         # https://api.relayr.io/transmitters/<id>
         url = '{0}/transmitters/{1}'.format(self.host, transmitterID)

--- a/relayr/api.py
+++ b/relayr/api.py
@@ -938,7 +938,7 @@ class Api(object):
         _, data = self.perform_request('GET', url)
         return data
 
-    def post_device(self, name, ownerID, modelID, firmwareVersion):
+    def post_device(self, name, ownerID, modelID, firmwareVersion, integrationType=None):
         """
         Register a new device on the relayr platform.
 
@@ -950,6 +950,8 @@ class Api(object):
         :type modelID: string
         :param firmwareVersion: the device's firmware version
         :type firmwareVersion: string
+        :param integrationType: the transmitter integration type
+        :type integrationType: string
         :rtype: list of dicts, each representing a relayr device
         """
         data = {
@@ -958,6 +960,8 @@ class Api(object):
           "model": modelID,
           "firmwareVersion": firmwareVersion
         }
+        if integrationType is not None:
+            data.update(integrationType=integrationType)
         # https://api.relayr.io/devices
         url = '{0}/devices'.format(self.host)
         _, data = self.perform_request('POST', url, data=data, headers=self.headers)
@@ -1365,8 +1369,8 @@ class Api(object):
         :type ownerID: string
         :param name: the transmitter name
         :type name: string
-        :param connector: the transmitter connector
-        :type connector: string
+        :param integrationType: the transmitter integration type
+        :type integrationType: string
         :rtype: an empty dict(?)
         """
         data = {}

--- a/relayr/api.py
+++ b/relayr/api.py
@@ -1355,7 +1355,7 @@ class Api(object):
         _, data = self.perform_request('GET', url, headers=self.headers)
         return data
 
-    def post_transmitter(self, transmitterID, ownerID=None, name=None):
+    def post_transmitter(self, transmitterID, ownerID=None, name=None, connector=None):
         """
         Register a new transmitter on the relayr platform.
 
@@ -1365,6 +1365,8 @@ class Api(object):
         :type ownerID: string
         :param name: the transmitter name
         :type name: string
+        :param connector: the transmitter connector
+        :type connector: string
         :rtype: an empty dict(?)
         """
         data = {}
@@ -1372,6 +1374,8 @@ class Api(object):
             data.update(owner=ownerID)
         if name is not None:
             data.update(name=name)
+        if connector is not None:
+            data.update(connector=connector)
 
         # https://api.relayr.io/transmitters/<id>
         url = '{0}/transmitters/{1}'.format(self.host, transmitterID)

--- a/relayr/api.py
+++ b/relayr/api.py
@@ -983,7 +983,7 @@ class Api(object):
           "owner": ownerID,
           "model": modelID,
           "firmwareVersion": firmwareVersion,
-          "integrationType": "Wunderbar2",
+          "integrationType": "wunderbar2",
           "mac": mac,
           "transmitterId": transmitterId
         }

--- a/relayr/api.py
+++ b/relayr/api.py
@@ -938,7 +938,7 @@ class Api(object):
         _, data = self.perform_request('GET', url)
         return data
 
-    def post_device(self, name, ownerID, modelID, firmwareVersion, integrationType=None):
+    def post_device(self, name, ownerID, modelID, firmwareVersion):
         """
         Register a new device on the relayr platform.
 
@@ -950,8 +950,6 @@ class Api(object):
         :type modelID: string
         :param firmwareVersion: the device's firmware version
         :type firmwareVersion: string
-        :param integrationType: the transmitter integration type
-        :type integrationType: string
         :rtype: list of dicts, each representing a relayr device
         """
         data = {
@@ -960,12 +958,40 @@ class Api(object):
           "model": modelID,
           "firmwareVersion": firmwareVersion
         }
-        if integrationType is not None:
-            data.update(integrationType=integrationType)
         # https://api.relayr.io/devices
         url = '{0}/devices'.format(self.host)
         _, data = self.perform_request('POST', url, data=data, headers=self.headers)
         return data
+
+
+    def post_device_wb2(self, name, ownerID, modelID, firmwareVersion, mac, transmitterId):
+        """
+        Register a new device on the relayr platform.
+
+        :param name: the device name
+        :type name: string
+        :param ownerID: the device owner's UUID
+        :type ownerID: string
+        :param modelID: the device model's UUID
+        :type modelID: string
+        :param firmwareVersion: the device's firmware version
+        :type firmwareVersion: string
+        :rtype: list of dicts, each representing a relayr device
+        """
+        data = {
+          "name": name,
+          "owner": ownerID,
+          "model": modelID,
+          "firmwareVersion": firmwareVersion,
+          "integrationType": "Wunderbar2",
+          "mac": mac,
+          "transmitterId": transmitterId
+        }
+        # https://api.relayr.io/devices
+        url = '{0}/devices'.format(self.host)
+        _, data = self.perform_request('POST', url, data=data, headers=self.headers)
+        return data
+
 
     def get_device(self, deviceID):
         """


### PR DESCRIPTION
@deeplook we have changed the way transmitters are created, users now need to provide a string called connector, you can read more on this confluence page https://relayr.atlassian.net/wiki/display/TTY/weekly+release+notes, it's not a breaking change because that endpoint was never used but will be used for the V2 of the wunderbar. Lemme know when you merge because I have to change our integration test.