### PR TITLE
noise.py: support SMTP-SSL, field SMTP_SENDER

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,8 @@ __pycache__
 # OS X temporary files that should never be committed
 ########################################
 .DS_Store
+
+########################################
+# Template files that usually are not committed
+########################################
+demos/odbclogger_ini.py

--- a/demos/noise.py
+++ b/demos/noise.py
@@ -29,6 +29,8 @@ RECEIVER = '...'
 SMTP_SERVER = '...'
 SMTP_USERNAME = '...'
 SMTP_PASSWORD = '' # will be requested at run time if left empty 
+SMTP_SENDER = 'Wunderbar <notification-noreply@relayr.io>'
+SMTP_SSL = 'yes'
 
 try:
     settings = [ACCESS_TOKEN, MICROPHONE_ID, RECEIVER, SMTP_SERVER, SMTP_USERNAME]
@@ -49,13 +51,16 @@ class Callbacks(object):
     def send_email(self, text):
         "Send an email notification."
         
-        sender = 'Wunderbar <notification-noreply@relayr.io>'
+        sender = SMTP_SENDER
         subject = 'Wunderbar Notification from Device: %s' % self.device.name
         msg = MIMEText(text)
         msg['Subject'] = subject
         msg['From'] = sender
         msg['To'] = RECEIVER
-        s = smtplib.SMTP(SMTP_SERVER)
+	if SMTP_SSL == 'yes':
+            s = smtplib.SMTP_SSL(SMTP_SERVER)
+	else:
+            s = smtplib.SMTP(SMTP_SERVER)
         prompt = "SMTP user password for user '%s'? " % SMTP_USERNAME
         global SMTP_PASSWORD
         SMTP_PASSWORD = SMTP_PASSWORD or getpass.getpass(prompt)

--- a/demos/odbclogger.py
+++ b/demos/odbclogger.py
@@ -1,0 +1,104 @@
+#!/usr/bin/python
+
+"""
+Example script accessing data from a WunderBar sensor via MQTT.
+
+This will connect to the MQTT server and wirte the sensor data
+to an ODBC server.
+
+Please, maintain access data in odbclogger_ini.py.
+"""
+
+import pyodbc
+import json
+import sys
+import time
+
+from relayr import Client
+from relayr.resources import Device
+from relayr.dataconnection import MqttStream
+
+# Include properties file.
+from odbclogger_ini import *
+
+# Check that all properties needed are set.
+try:
+    settings = [ACCESS_TOKEN, SENSOR_ID, ODBC_DSN]
+    assert not any(map(lambda x: x=='', settings))
+except AssertionError:
+    print('Please, provide values in file odbclogger_ini.py.')
+    sys.exit(1)
+
+class Callbacks(object):
+    "A class providing callbacks for incoming data from some device."
+
+    def __init__(self, device, cursor):
+        "Constructor."
+        self.device = device
+        self.cursor = cursor
+
+    def sensor(self, topic, message):
+        "Callback to log sensor data to SQL database."
+
+        readings = json.loads(message)['readings']
+        sql = 'INSERT INTO wunderdata (device, sensor, value) VALUES (?, ?, ?)'
+        sys.stdout.write(self.device.name + ': ')
+        for r in readings:
+            self.cursor.execute(sql, \
+                self.device.name, r['meaning'], r['value']).commit()
+            sys.stdout.write( r['meaning'] + ' = ' + str(r['value']) + '; ')
+        sys.stdout.write('\n')
+
+def connect():
+    "Connect to a device and read data until interrupted by CTRL+C."
+
+    DSN = 'DSN=' + ODBC_DSN
+    if ODBC_USER:
+        DSN += ';UID=' + ODBC_USER
+    if ODBC_PASSWORD:
+        DSN += ';PWD=' + ODBC_PASSWORD
+
+    # Connect to dtabase.
+    cnxn = pyodbc.connect(DSN)
+    cursor = cnxn.cursor()
+
+    print("Connected to database")
+
+    try:
+        # Check if database table already exists.
+        cursor.execute("SELECT id, time, sensor, value FROM wunderdata")
+    except: # catch all
+        cursor.execute("""
+            CREATE TABLE wunderdata (
+              id     INT NOT NULL AUTO_INCREMENT,
+              device CHAR(40) NOT NULL,
+              sensor CHAR(20) NOT NULL,
+              time   TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+              value  float NOT NULL,
+              PRIMARY KEY (id),
+              KEY data (device, sensor, time)
+              )""" )
+        cursor.commit()
+
+    c = Client(token=ACCESS_TOKEN)
+    device = Device(id=SENSOR_ID, client=c).get_info()
+    callbacks = Callbacks(device, cursor)
+    print("Monitoring '%s' (%s) ..." % (device.name, device.id))
+    try:
+        # Loop until interrupted by keyboard.
+        while True:
+            stream = MqttStream(callbacks.sensor, [device], transport='mqtt')
+            stream.start()
+            time.sleep(10)
+            stream.stop()
+    except KeyboardInterrupt:
+        print('')
+        stream.stop()
+    print("Stopped")
+
+    # Close database connection.
+    cnxn.close()
+
+# Entry point.
+if __name__ == "__main__":
+    connect()

--- a/demos/odbclogger_ini.py
+++ b/demos/odbclogger_ini.py
@@ -1,0 +1,19 @@
+#!/usr/bin/python
+
+"""
+odbclogger_ini.py
+
+This file is used to provide the credentials for the
+odbc logging example.
+"""
+
+# Replace with your own values.
+
+# Wunderbar.
+ACCESS_TOKEN   = ''
+SENSOR_ID      = ''
+
+# Database connection.
+ODBC_DSN       = ''
+ODBC_USER      = '' # can be left empty if not needed
+ODBC_PASSWORD  = '' # can be left empty if not needed


### PR DESCRIPTION
Many mails servers do not support unencrypted SMTP.
SMTP_SSL is provided as switch.

Some mail servers do not allow to provide an arbitrary address
for 'MAIL FROM:'. Field SMTP_SENDER is used to set this field.

Signed-off-by: Heinrich Schuchardt <xypron.glpk@gmx.de>